### PR TITLE
Revert "Dockerfile: ADD /app"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update && apt-get install -y fortunes libespeak-dev
 ADD requirements.txt /home/vmagent/app/
 RUN pip install -r requirements.txt
 
-ADD . /app
+ADD . /home/vmagent/app/


### PR DESCRIPTION
Reverts GoogleCloudPlatform/appengine-vm-fortunespeak-python#13

Doesn't fix `ADD requirements.txt`
