### PR TITLE
Bugfix. I think this was rare and happened only on cache hit.

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ def synth_fortune():
     digest = md5.new(msg).hexdigest()
     path = os.path.join(CACHE, digest)
     if os.path.exists(path):
-        return redirect(url_for(serve_fortune, path=digest))
+        return redirect(url_for('serve_fortune', path=digest))
     os.makedirs(path)
     with open(os.path.join(CACHE, digest, 'message.txt'), 'w') as f:
         f.write(msg)


### PR DESCRIPTION
Traceback (most recent call last):
...
File "/home/vmagent/app/main.py", line 40, in synth_fortune
  return redirect(url_for(serve_fortune, path=digest))
File "/usr/local/lib/python2.7/dist-packages/flask/helpers.py", line 268, in url_for
  if endpoint[:1] == '.':
TypeError: 'function' object has no attribute '__getitem__'